### PR TITLE
Suggest --bind localhost for local preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ shinylive export myapp site
 Then you can preview the application by running a web server and visiting it in a browser:
 
 ```
-python3 -m http.server --directory site 8008
+python3 -m http.server --directory site --bind localhost 8008
 ```
 
 At this point, you can deploy the `site/` directory to any static web hosting service.

--- a/shinylive/_export.py
+++ b/shinylive/_export.py
@@ -111,6 +111,7 @@ def export(
     )
 
     print(
-        f"\nRun the following to serve the app:\n  python3 -m http.server --directory {destdir} 8008",
+        "\nRun the following to serve the app:\n"
+        f"  python3 -m http.server --directory {destdir} --bind localhost 8008",
         file=sys.stderr,
     )

--- a/shinylive/_main.py
+++ b/shinylive/_main.py
@@ -42,7 +42,7 @@ This command will not include the contents of venv/ or any files that start with
 
 After writing the output files, you can serve them locally with the following command:
 
-    python3 -m http.server --directory DESTDIR 8008
+    python3 -m http.server --directory DESTDIR --bind localhost 8008
 """,
     no_args_is_help=True,
 )


### PR DESCRIPTION
Otherwise, the app just displays the following message:

> Shinylive uses a Service Worker, which requires either a connection to
> localhost, or a connection via https.