### PR TITLE
Fix for pyright error

### DIFF
--- a/shinylive/_main.py
+++ b/shinylive/_main.py
@@ -4,7 +4,7 @@ import collections
 import json
 import sys
 from pathlib import Path
-from typing import Literal, MutableMapping, Optional, Callable, Any
+from typing import Any, Callable, Literal, MutableMapping, Optional
 
 import click
 

--- a/shinylive/_main.py
+++ b/shinylive/_main.py
@@ -4,7 +4,7 @@ import collections
 import json
 import sys
 from pathlib import Path
-from typing import Literal, MutableMapping, Optional
+from typing import Literal, MutableMapping, Optional, Callable, Any
 
 import click
 
@@ -20,9 +20,23 @@ class OrderedGroup(click.Group):
         self,
         name: Optional[str] = None,
         commands: Optional[MutableMapping[str, click.Command]] = None,
+        invoke_without_command: bool = False,
+        no_args_is_help: bool | None = None,
+        subcommand_metavar: str | None = None,
+        chain: bool = False,
+        result_callback: Callable[..., Any] | None = None,
         **kwargs: object,
     ):
-        super(OrderedGroup, self).__init__(name, commands, **kwargs)
+        super(OrderedGroup, self).__init__(
+            name,
+            commands,
+            invoke_without_command=invoke_without_command,
+            no_args_is_help=no_args_is_help,
+            subcommand_metavar=subcommand_metavar,
+            chain=chain,
+            result_callback=result_callback,
+            **kwargs,
+        )
         #: the registered subcommands by their exported names.
         self.commands = commands or collections.OrderedDict()
 


### PR DESCRIPTION
This fixes the following pyright errors (https://github.com/posit-dev/py-shinylive/actions/runs/16580015762/job/46893662696):

```
pyright
/home/runner/work/py-shinylive/py-shinylive/shinylive/_main.py
  /home/runner/work/py-shinylive/py-shinylive/shinylive/_main.py:25:62 - error: Argument of type "object" cannot be assigned to parameter "invoke_without_command" of type "bool" in function "__init__"
    "object" is not assignable to "bool" (reportArgumentType)
  /home/runner/work/py-shinylive/py-shinylive/shinylive/_main.py:25:62 - error: Argument of type "object" cannot be assigned to parameter "no_args_is_help" of type "bool | None" in function "__init__"
    Type "object" is not assignable to type "bool | None"
      "object" is not assignable to "bool"
      "object" is not assignable to "None" (reportArgumentType)
  /home/runner/work/py-shinylive/py-shinylive/shinylive/_main.py:25:62 - error: Argument of type "object" cannot be assigned to parameter "subcommand_metavar" of type "str | None" in function "__init__"
    Type "object" is not assignable to type "str | None"
      "object" is not assignable to "str"
      "object" is not assignable to "None" (reportArgumentType)
  /home/runner/work/py-shinylive/py-shinylive/shinylive/_main.py:25:62 - error: Argument of type "object" cannot be assigned to parameter "chain" of type "bool" in function "__init__"
    "object" is not assignable to "bool" (reportArgumentType)
  /home/runner/work/py-shinylive/py-shinylive/shinylive/_main.py:25:62 - error: Argument of type "object" cannot be assigned to parameter "result_callback" of type "((...) -> Any) | None" in function "__init__"
    Type "object" is not assignable to type "((...) -> Any) | None"
      Type "object" is not assignable to type "(...) -> Any"
      "object" is not assignable to "None" (reportArgumentType)
5 errors, 0 warnings, 0 informations 
make: *** [Makefile:52: pyright] Error 1
```


The error is new due to a change in the `Group.__init__` method from the `click` package.

In 8.1.8, it looked like this (https://github.com/pallets/click/blob/8.1.8/src/click/core.py#L1827-L1832):

```py
class Group(Command): 

    def __init__(
        self,
        name: t.Optional[str] = None,
        commands: t.Optional[
            t.Union[t.MutableMapping[str, Command], t.Sequence[Command]]
        ] = None,
        **attrs: t.Any,
    ) -> None:
```

In 8.2.0, it change to this, with some new named arguments (https://github.com/pallets/click/blob/8.2.0/src/click/core.py#L1513-L1525):

```py
class Group(Command): 

    def __init__(
        self,
        name: str | None = None,
        commands: cabc.MutableMapping[str, Command]
        | cabc.Sequence[Command]
        | None = None,
        invoke_without_command: bool = False,
        no_args_is_help: bool | None = None,
        subcommand_metavar: str | None = None,
        chain: bool = False,
        result_callback: t.Callable[..., t.Any] | None = None,
        **kwargs: t.Any,
    ) -> None:
```


I added those same named arguments to the new class. I think it should be fine with older versions of click -- it passes type checking with click 8.1.7 and the latest, 8.2.1.
