### PR TITLE
release: py-shinylive v0.8.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.8.7] - 2026-05-01
+
+* Updated to Shinylive web assets 0.10.9.
+
 ## [0.8.6] - 2026-03-20
 
 * Updated to Shinylive web assets 0.10.8.

--- a/shinylive/_version/__init__.py
+++ b/shinylive/_version/__init__.py
@@ -1,5 +1,5 @@
 # The version of this Python package.
-SHINYLIVE_PACKAGE_VERSION = "0.8.6"
+SHINYLIVE_PACKAGE_VERSION = "0.8.7"
 
 # This is the version of the Shinylive assets to use.
-SHINYLIVE_ASSETS_VERSION = "0.10.8"
+SHINYLIVE_ASSETS_VERSION = "0.10.9"


### PR DESCRIPTION
## Summary

* Updated to Shinylive web assets 0.10.9.

## Test plan

- [ ] CI passes