### PR TITLE
release: v0.8.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.8.8] - 2026-05-21
+
+* Updated to Shinylive web assets 0.10.10.
+
 ## [0.8.7] - 2026-05-01
 
 * Updated to Shinylive web assets 0.10.9.

--- a/shinylive/_version/__init__.py
+++ b/shinylive/_version/__init__.py
@@ -1,5 +1,5 @@
 # The version of this Python package.
-SHINYLIVE_PACKAGE_VERSION = "0.8.7"
+SHINYLIVE_PACKAGE_VERSION = "0.8.8"
 
 # This is the version of the Shinylive assets to use.
-SHINYLIVE_ASSETS_VERSION = "0.10.9"
+SHINYLIVE_ASSETS_VERSION = "0.10.10"


### PR DESCRIPTION
## Summary

Release **py-shinylive v0.8.8**, bundling shinylive web assets **v0.10.10** (which ships py-shiny v1.6.2, htmltools v0.7.0, and shinywidgets v0.8.1).

## Changes

- `SHINYLIVE_PACKAGE_VERSION` → `0.8.8`
- `SHINYLIVE_ASSETS_VERSION` → `0.10.10`
- CHANGELOG entry

## Test plan

- [x] CI passes
- [ ] After merge: tag, GH Release, PyPI publish succeeds