### PR TITLE
release: v0.8.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.8.9] - 2026-06-01
+
+* Updated to Shinylive web assets 0.10.12.
+
 ## [0.8.8] - 2026-05-21
 
 * Updated to Shinylive web assets 0.10.10.

--- a/shinylive/_version/__init__.py
+++ b/shinylive/_version/__init__.py
@@ -1,5 +1,5 @@
 # The version of this Python package.
-SHINYLIVE_PACKAGE_VERSION = "0.8.8"
+SHINYLIVE_PACKAGE_VERSION = "0.8.9"
 
 # This is the version of the Shinylive assets to use.
-SHINYLIVE_ASSETS_VERSION = "0.10.10"
+SHINYLIVE_ASSETS_VERSION = "0.10.12"


### PR DESCRIPTION
Updates the Python `shinylive` package to bundle **Shinylive web assets 0.10.12** (which ship py-shiny 1.6.3).

- `SHINYLIVE_PACKAGE_VERSION` → 0.8.9
- `SHINYLIVE_ASSETS_VERSION` → 0.10.12

---
Part of the py-shiny v1.6.3 release train. See posit-dev/py-shiny#2266.