### PR TITLE
release: v0.8.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.8.10] - 2026-07-28
 
-* Updated to Shinylive web assets 0.10.13, which bundle Shiny for Python 1.6.4. That release fixes a path-traversal vulnerability in bookmark restore (CWE-22).
+* Updated to Shinylive web assets 0.10.13, which bundles Shiny for Python 1.6.4.
 
 ## [0.8.9] - 2026-06-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.8.10] - 2026-07-28
+
+* Updated to Shinylive web assets 0.10.13, which bundle Shiny for Python 1.6.4. That release fixes a path-traversal vulnerability in bookmark restore (CWE-22).
+
 ## [0.8.9] - 2026-06-01
 
 * Updated to Shinylive web assets 0.10.12.

--- a/shinylive/_version/__init__.py
+++ b/shinylive/_version/__init__.py
@@ -1,5 +1,5 @@
 # The version of this Python package.
-SHINYLIVE_PACKAGE_VERSION = "0.8.9"
+SHINYLIVE_PACKAGE_VERSION = "0.8.10"
 
 # This is the version of the Shinylive assets to use.
-SHINYLIVE_ASSETS_VERSION = "0.10.12"
+SHINYLIVE_ASSETS_VERSION = "0.10.13"


### PR DESCRIPTION
Updates to Shinylive web assets **0.10.13**, which bundle **Shiny for Python 1.6.4** and its bookmark path-traversal security fix (CWE-22).

## Changes

- `SHINYLIVE_PACKAGE_VERSION`: 0.8.9 → 0.8.10
- `SHINYLIVE_ASSETS_VERSION`: 0.10.12 → 0.10.13
- `CHANGELOG.md` entry

## Verification

Installed the branch and ran a real export end-to-end:

```
$ shinylive export /tmp/sl-app /tmp/sl-export
Copying imported packages from ~/Library/Caches/shinylive/shinylive-0.10.13/shinylive/pyodide/ …

$ ls /tmp/sl-export/shinylive/pyodide/ | grep ^shiny-
shiny-1.6.4-py3-none-any.whl
```

So the new assets version resolves, downloads from the [v0.10.13 release](https://github.com/posit-dev/shinylive/releases/tag/v0.10.13), and exported apps bundle 1.6.4.

No git-based dependencies in `pyproject.toml`.

## Note

The 0.10.13 assets still bundle `shinyswatch` 0.8.0 — posit-dev/shinylive#235 bumped it to 0.11.0 but landed after the v0.10.13 tag, so it will ship in the next assets release.