### PR TITLE
release: v0.8.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.8.11] - 2026-07-29
+
+* Updated to Shinylive web assets 0.10.14, which bundles Shiny for Python 1.7.0.
+
 ## [0.8.10] - 2026-07-28
 
 * Updated to Shinylive web assets 0.10.13, which bundles Shiny for Python 1.6.4.

--- a/shinylive/_version/__init__.py
+++ b/shinylive/_version/__init__.py
@@ -1,5 +1,5 @@
 # The version of this Python package.
-SHINYLIVE_PACKAGE_VERSION = "0.8.10"
+SHINYLIVE_PACKAGE_VERSION = "0.8.11"
 
 # This is the version of the Shinylive assets to use.
-SHINYLIVE_ASSETS_VERSION = "0.10.13"
+SHINYLIVE_ASSETS_VERSION = "0.10.14"


### PR DESCRIPTION
Release prep for **py-shinylive 0.8.11**, tracking the [shinylive v0.10.14](https://github.com/posit-dev/shinylive/releases/tag/v0.10.14) web assets.

## Changes

`shinylive/_version/__init__.py`:

```diff
-SHINYLIVE_PACKAGE_VERSION = "0.8.10"
+SHINYLIVE_PACKAGE_VERSION = "0.8.11"
-SHINYLIVE_ASSETS_VERSION = "0.10.13"
+SHINYLIVE_ASSETS_VERSION = "0.10.14"
```

`CHANGELOG.md`: `## [0.8.11] - 2026-07-29` — *"Updated to Shinylive web assets 0.10.14, which bundles Shiny for Python 1.7.0."*

No git-based dependencies. `main` was identical to `v0.8.10`, so this is a clean base.

## Verification

Installed the branch (`pip install -e .`) and exercised the real download-and-export path against the published release artifact, rather than just checking the constants:

```
$ shinylive --help
  shinylive Python package version: 0.8.11
  shinylive web assets version:     0.10.14

$ shinylive assets download
Downloading https://github.com/posit-dev/shinylive/releases/download/v0.10.14/shinylive-0.10.14.tar.gz...
Unzipping to ~/Library/Caches/shinylive/
```

Exported an Express app and confirmed the bundle it produced carries the new packages:

| Package in exported `pyodide-lock.json` | Version |
|---|---|
| shiny | **1.7.0** |
| shinyswatch | **0.12.0** |
| htmltools | 0.7.0 |

Then served the export and drove it in a real browser:

- App renders: `n*2 is 40` (slider default 20) — correct
- Reactivity round-trips: setting the slider to 77 updated the output to `n*2 is 154`
- No Python traceback, **0** `.shiny-output-error`, **0** console errors

Part of the py-shiny v1.7.0 release train; see posit-dev/py-shiny#2377.