### PR TITLE
ci: Test on Python 3.14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         # "3.10" must be a string; otherwise it is interpreted as 3.1.
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
       fail-fast: false
 
     steps:

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ classifiers =
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.14
 project_urls =
     Bug Tracker = https://github.com/posit-dev/py-shinylive/issues
     Documentation = https://github.com/posit-dev/py-shinylive


### PR DESCRIPTION
## Why

py-shinylive's CI matrix stopped at 3.13, while py-shiny and py-shinyswatch already test 3.14. That made py-shinylive the only package in the release train not exercised on the newest interpreter — and it's the one that wires the others together for `shinylive export`. Noticed while running the v1.7.0 release train.

## What

- `.github/workflows/build.yml`: add `"3.14"` to the build matrix
- `setup.cfg`: add the matching `Programming Language :: Python :: 3.14` classifier, so the advertised support matches what's tested

`python_requires = >=3.10` is unchanged.

## Verification

Built and tested against 3.14 locally before asking CI to assert it:

```
$ python --version
Python 3.14.1
$ python -m pytest tests/ -q
13 passed
```

`import shinylive` resolves and reports version 0.8.11.

Follow-up to #63; part of the py-shiny v1.7.0 release train (see posit-dev/py-shiny#2377).